### PR TITLE
Fix mime-type handling for uploads.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
   "rules": {
     "no-comma-dangle": 2,
     "no-cond-assign": [2, "except-parens"],
-    "no-console": 1,
+    "no-console": 0,
     "no-constant-condition": 2,
     "no-control-regex": 2,
     "no-debugger": 1,

--- a/index.js
+++ b/index.js
@@ -30,13 +30,7 @@ const buildPath = path.resolve(commander.path),
   slack = new Slack(gcloudConfig.slackWebHook);
 
 let storage, bucket, files,
-  asyncTasks = [],
-  fileOptions = {
-    validation: 'crc32c',
-    metadata: {
-      cacheControl: 'no-cache'
-    }
-  };
+  asyncTasks = [];
 
 storage = gcloud({
   projectId: gcloudConfig.projectId,
@@ -56,7 +50,14 @@ files = readDir(buildPath, (file) => {
 console.log(`Will upload ${files.length} files to:\n${webRoot}\n`);
 
 files.forEach(file => {
-  asyncTasks.push((done) => {
+  let fileOptions = {
+    validation: 'crc32c',
+    metadata: {
+      cacheControl: 'no-cache'
+    }
+  };
+
+  asyncTasks.push(done => {
     fileOptions.metadata.contentType = mime.lookup(file);
     fileOptions.destination = gcloudConfig.remotePath + file;
 

--- a/index.js
+++ b/index.js
@@ -53,14 +53,13 @@ files.forEach(file => {
   let fileOptions = {
     validation: 'crc32c',
     metadata: {
-      cacheControl: 'no-cache'
-    }
+      cacheControl: 'no-cache',
+      contentType: mime.lookup(file)
+    },
+    destination: gcloudConfig.remotePath + file
   };
 
   asyncTasks.push(done => {
-    fileOptions.metadata.contentType = mime.lookup(file);
-    fileOptions.destination = gcloudConfig.remotePath + file;
-
     bucket.upload(
       path.resolve(buildPath, file),
       fileOptions,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const buildPath = path.resolve(commander.path),
   keyFilename = path.resolve('.gcloud.json'),
   webRoot = `https://storage.googleapis.com/` +
     `${gcloudConfig.bucket}/` +
-    `${gcloudConfig.remotePath}index.html`,
+    `${gcloudConfig.remotePath}`,
   slack = new Slack(gcloudConfig.slackWebHook);
 
 let storage, bucket, files,
@@ -47,7 +47,7 @@ files = readDir(buildPath, (file) => {
   return !/(^\.)/.test(file[0]);
 });
 
-console.log(`Will upload ${files.length} files to:\n${webRoot}\n`);
+console.info(`Will upload ${files.length} files to:\n${webRoot}\n`);
 
 files.forEach(file => {
   let fileOptions = {
@@ -63,19 +63,19 @@ files.forEach(file => {
 
     bucket.upload(
       path.resolve(buildPath, file),
-      fileOptions, (error, remoteFile) => {
+      fileOptions,
+      (error, remoteFile) => {
         if (error) {
           throw new Error(error);
         }
-
-        console.log(`${file} uploaded to ${remoteFile.name}.`);
+        console.info(`${file} uploaded to ${remoteFile.name}.`);
         done();
       });
   });
 });
 
 async.parallelLimit(asyncTasks, 10, function() {
-  console.log('\nUpload done!');
+  console.info('\nUpload done!');
 
   const slackChannel = commander.slackChannel || gcloudConfig.slackWebHook;
 


### PR DESCRIPTION
Initializing `fileOptions` object for each file.
This prevents wrong mime types for a file as it initializes the options object
for each async file upload.
