### PR TITLE
Add remote path options to cli.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "0.12"
-  - "iojs"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The options available:
 
 * `-s, --slack-channel <slack-channel>`
 * `-p, --path <local-path>`
+* `-r, --remotePath <remote-path>`
 * `-c, --configFile <path-to-config>`
 
-All files in `path` directory will be uploaded to `remotePath` given in `.gcloud.json`. Slack channel is optional.
+All files in `path` directory will be uploaded to `remotePath` given in `.gcloud.json` or via the options. Slack channel is optional. The options overwrite the `.gcloud.json` settings.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ commander
     'The slack channel to post to.'
   )
   .option(
+    '-r, --remotePath <remote-path>',
+    'The path on gcloud storage'
+  )
+  .option(
     '-p, --path <local-path>',
     'The local path.'
   )
@@ -27,9 +31,10 @@ const keyFilePath = path.resolve(commander.configFile || '.gcloud.json'),
   gcloudConfig = require(keyFilePath),
   packageJson = require(path.resolve('package.json')),
   sourcePath = path.resolve(commander.path),
+  remotePath = commander.remotePath || gcloudConfig.remotePath,
   webRoot = `https://storage.googleapis.com/` +
     `${gcloudConfig.bucket}/` +
-    `${gcloudConfig.remotePath}`,
+    `${remotePath}`,
   slack = new Slack(gcloudConfig.slackWebHook);
 
 let storage, bucket, files,
@@ -59,7 +64,7 @@ files.forEach(file => {
       cacheControl: 'no-cache',
       contentType: mime.lookup(file)
     },
-    destination: gcloudConfig.remotePath + file
+    destination: remotePath + file
   };
 
   asyncTasks.push(done => {


### PR DESCRIPTION
Now you cloud upload to dynamic folders.

For example use the `npm_package_version` environment
to set a folder for each version.
