### PR TITLE
fix(path-concat): replace url concat with proper concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import path from 'path';
+import urljoin from 'url-join';
 import readDir from 'fs-readdir-recursive';
 import mime from 'mime';
 import async from 'async';
@@ -32,9 +33,11 @@ const keyFilePath = path.resolve(commander.configFile || '.gcloud.json'),
   packageJson = require(path.resolve('package.json')),
   sourcePath = path.resolve(commander.path),
   remotePath = commander.remotePath || gcloudConfig.remotePath,
-  webRoot = `https://storage.googleapis.com/` +
-    `${gcloudConfig.bucket}/` +
-    `${remotePath}`,
+  webRoot = urljoin(
+    'https://storage.googleapis.com/',
+    gcloudConfig.bucket,
+    remotePath
+  ),
   slack = new Slack(gcloudConfig.slackWebHook);
 
 let storage, bucket, files,
@@ -64,7 +67,7 @@ files.forEach(file => {
       cacheControl: 'no-cache',
       contentType: mime.lookup(file)
     },
-    destination: remotePath + file
+    destination: urljoin(remotePath, file)
   };
 
   asyncTasks.push(done => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel": "^5.6.14",
     "bumpery": "^1.1.1",
     "conventional-changelog-generator": "0.0.3",
-    "eslint": "^0.24.0"
+    "eslint": "^0.24.0",
+    "url-join": "0.0.1"
   }
 }


### PR DESCRIPTION
Path concatenation was performed as string concatenation. This is error prone if leading or tailing slashes are not set properly.

Now uses the `url-join` module for proper concatenation: https://www.npmjs.com/package/url-join
