### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   "dependencies": {
     "async": "^1.3.0",
     "commander": "^2.8.1",
-    "fs-readdir-recursive": "^0.1.2",
-    "gcloud": "^0.23.0",
+    "fs-readdir-recursive": "^1.0.0",
+    "gcloud": "^0.25.1",
     "mime": "^1.3.4",
     "node-slack": "0.0.7",
-    "path": "^0.11.14"
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "babel": "^5.6.14",


### PR DESCRIPTION
Fails installing in Node 5.1 with old versions. Please publish after merge.
