### PR TITLE
Removes version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ The options available:
 * `-s, --slack-channel <slack-channel>`
 * `-p, --path <local-path>`
 * `-r, --remotePath <remote-path>`
-* `-v, --versionNumber <version-number>`
 * `-c, --configFile <path-to-config>`
 
 All files in `path` directory will be uploaded to `remotePath` given in `.gcloud.json` or via the options.  
-An optional `versionNumber` number (given via the `.gcloud.json` or the options) will be added as sub directory. Use `$npm_package_version` to include it directly from the `package.json`.
-Slack channel is optional.  
+The slack channel is optional.  
+
 The options overwrite the `.gcloud.json` settings.

--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,6 @@ commander
     'The local path (defaults to current path).'
   )
   .option(
-    '-v, --versionNumber <version-number>',
-    'The version number is added as additional subfolder to the local path.'
-  )
-  .option(
     '-c, --configFile <path-to-config>',
     'The local config file.'
   )
@@ -36,10 +32,7 @@ const keyFilePath = path.resolve(commander.configFile || '.gcloud.json'),
   gcloudConfig = require(keyFilePath),
   packageJson = require(path.resolve('package.json')),
   sourcePath = commander.path ? path.resolve(commander.path) : process.cwd(),
-  remotePath = urljoin(
-    commander.remotePath || gcloudConfig.remotePath || '',
-    commander.versionNumber || gcloudConfig.versionNumber || ''
-  ),
+  remotePath = commander.remotePath || gcloudConfig.remotePath || '',
   webRoot = urljoin(
     gcloudConfig.bucket,
     remotePath


### PR DESCRIPTION
As this was only a very optinionated option to adjust ther remote path
option. Just add the desired version to the remotePath optn and you will
be fine.

Might be breaking.