### PR TITLE
Feat/gzip extensions

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,3 +1,4 @@
-version: v1.5.2
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
 ignore: {}
 patch: {}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A `.gcloud.json` must be present in the root folder of the project. This is basi
   "versionNumber": "ADDITIONAL SUBPATH INSIDE THE BUCKET (optional)^"
   "slackWebHook": "SLACK WEB HOOK (optional)",
   "slackChannel": "SLACK CHANNEL TO POST TO (optional, can be set/overwritten by commandline)",
-  "metadata": "METADATA FOR UPLOADED FILES (optional, default is {cacheControl: 'no-cache'})"
+  "metadata": "METADATA FOR UPLOADED FILES (optional, default is {cacheControl: 'no-cache'})",
+  "gzipExtensions": "OPTIONAL ARRAY OF FILE EXTENSIONS WHICH SHOULD BE UPLOADED WITH GZIP CONTENT ENCODING: ['js', 'css', 'html', 'csv'] "
 }
 ```
 
@@ -38,7 +39,7 @@ The options available:
 * `-r, --remotePath <remote-path>`
 * `-c, --configFile <path-to-config>`
 
-All files in `path` directory will be uploaded to `remotePath` given in `.gcloud.json` or via the options.  
-The slack channel is optional.  
+All files in `path` directory will be uploaded to `remotePath` given in `.gcloud.json` or via the options.
+The slack channel is optional.
 
 The options overwrite the `.gcloud.json` settings.

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@google-cloud/storage": "^1.2.0",
     "async": "^2.1.2",
     "commander": "^2.8.1",
     "fs-readdir-recursive": "^1.0.0",
-    "@google-cloud/storage": "^0.4.0",
     "mime": "^1.3.4",
     "node-slack": "0.0.7",
     "url-join": "^1.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,14 @@ console.info(`Will upload ${files.length} files to:` +
   `\nConsole-root: ${consoleRoot}\nWeb-root: ${webRoot}\n`);
 
 files.forEach(file => {
+  const {gzipExtensions} = gcloudConfig;
+  const extension = path.extname(file).replace('.', '');
+  const shouldGzip = gzipExtensions ?
+    gzipExtensions.includes(extension) :
+    false;
+
   const fileOptions = {
+    gzip: shouldGzip,
     validation: 'crc32c',
     metadata: Object.assign(
       {},


### PR DESCRIPTION
Tested this with a project, looks good. When `gzip` is set to `true`, the storage module will automatically set the `Content-Encoding` heading of the file and will gzip the file before uploading it.

closes #15 